### PR TITLE
SSL_OP_SINGLE_DH_USE - Always create a new key when using temporary/ephe...

### DIFF
--- a/libretroshare/src/pqi/authssl.cc
+++ b/libretroshare/src/pqi/authssl.cc
@@ -333,6 +333,8 @@ static  int initLib = 0;
 	// setup connection method
 	sslctx = SSL_CTX_new(SSLv23_method());
 	SSL_CTX_set_options(sslctx,SSL_OP_NO_SSLv3) ;
+	// Always create a new key when using temporary/ephemeral DH parameters
+	SSL_CTX_set_options(sslctx,SSL_OP_SINGLE_DH_USE);
 
 	// Setup cipher lists:
 	//


### PR DESCRIPTION
...meral DH parameters (see SSL_CTX_set_tmp_dh_callback). This option must be used to prevent small subgroup attacks, when the DH parameters were not generated using "strong" primes (e.g. when using DSA-parameters, see dhparam). If "strong" primes were used, it is not strictly necessary to generate a new DH key during each handshake but it is also recommended. SSL_OP_SINGLE_DH_USE should therefore be enabled whenever temporary/ephemeral DH parameters are used.
