### PR TITLE
Automate version detail

### DIFF
--- a/get_version.sh
+++ b/get_version.sh
@@ -12,24 +12,24 @@ if ( git log -n 1 &> /dev/null); then
 	
 	#try to try and pull SVN revision from last commit
 	cleverversion="$(git log -n 1 | awk '/svn/ {print $2}' | head -1 | sed 's/.*@//')"
-        if [ -z $cleverversion ]; then
-            #"failed to get SVN version from most recent git"
-            cleverversion="$(git log -n 10 | awk '/svn/ {print $2}' | head -1 | sed 's/.*@//')"
-        fi
-        
+		if [ -z $cleverversion ]; then
+			#"failed to get SVN version from most recent git"
+			cleverversion="$(git log -n 10 | awk '/svn/ {print $2}' | head -1 | sed 's/.*@//')"
+		fi
+		
 	#try to try and pull SVN revision from last 10 commits
-        if [ $cleverversion ]; then
-            #"got clever version"
-            version=$cleverversion
-        fi
+		if [ $cleverversion ]; then
+			#"got clever version"
+			version=$cleverversion
+		fi
 	
 	#if not got a version using smart method, use easy method
-        if [ $version == 0 ]; then
-            #retrieve git information - just get number of commits
-            #note - this will not match svn commits
-            #note - with caves repo - start of history is cutoff? so it is unusually small number
-            version=$(git rev-list HEAD | wc -l)
-        fi
+		if [ $version == 0 ]; then
+			#retrieve git information - just get number of commits
+			#note - this will not match svn commits
+			#note - with caves repo - start of history is cutoff? so it is unusually small number
+			version=$(git rev-list HEAD | wc -l)
+		fi
 	
 	vcs="git"
 	githash=$(git log --format="%H" -n 1)
@@ -38,20 +38,20 @@ elif ( svn info &> /dev/null); then
 	version=$(svn info | awk '/^Revision:/ {print $NF}')
 	vcs="svn"
 else
-    version=0001
-    vcs="error"
+	version=0001
+	vcs="error"
 fi
 
 #echo "version is $version from $vcs"
 if [ "$1" == "vcs" ]; then
-    echo $vcs
-    exit 0
+	echo $vcs
+	exit 0
 fi
 
 
 if [ "$1" == "githash" ]; then
-    echo $githash
-    exit 0
+	echo $githash
+	exit 0
 fi
 
 echo $version

--- a/get_version.sh
+++ b/get_version.sh
@@ -7,17 +7,27 @@ version=0
 vcs="unknown"
 githash="unknown"
 if ( git log -n 1 &> /dev/null); then
-	#retrieve git information - just get number of commits
-	#note - this will not match svn commits
-	#note - with caves repo - start of history is cutoff? so it is unusually small number
-	#note - should really provide hash of last git commit - this is *much* more handy for unoffical builds!
-	#where a single number is currently rather misleading
-	#though a version numer for approx human reading is nice!
+	#note - where a single number is currently rather misleading
+	#though a version numer for approx human reading is nice
 	
-	#this could still do some smart things HERE to try and pull SVN revision from logs
+	#try to try and pull SVN revision from last commit
+	cleverversion="$(git log -n 1 | awk '/svn/ {print $2}' | head -1 | sed 's/.*@//')"
+        if [ -z $cleverversion ]; then
+            #"failed to get SVN version from most recent git"
+            cleverversion="$(git log -n 10 | awk '/svn/ {print $2}' | head -1 | sed 's/.*@//')"
+        fi
+        
+	#try to try and pull SVN revision from last 10 commits
+        if [ $cleverversion ]; then
+            #"got clever version"
+            version=$cleverversion
+        fi
 	
 	#if not got a version using smart method, use easy method
         if [ $version == 0 ]; then
+            #retrieve git information - just get number of commits
+            #note - this will not match svn commits
+            #note - with caves repo - start of history is cutoff? so it is unusually small number
             version=$(git rev-list HEAD | wc -l)
         fi
 	

--- a/get_version.sh
+++ b/get_version.sh
@@ -3,8 +3,9 @@
 #don't exit even if a command fails
 set +e
 
-version=0001
+version=0
 vcs="unknown"
+githash="unknown"
 if ( git log -n 1 &> /dev/null); then
 	#retrieve git information - just get number of commits
 	#note - this will not match svn commits
@@ -12,8 +13,17 @@ if ( git log -n 1 &> /dev/null); then
 	#note - should really provide hash of last git commit - this is *much* more handy for unoffical builds!
 	#where a single number is currently rather misleading
 	#though a version numer for approx human reading is nice!
-	version=$(git rev-list HEAD | wc -l)
+	
+	#this could still do some smart things HERE to try and pull SVN revision from logs
+	
+	#if not got a version using smart method, use easy method
+        if [ $version == 0 ]; then
+            version=$(git rev-list HEAD | wc -l)
+        fi
+	
 	vcs="git"
+	githash=$(git log --format="%H" -n 1)
+	#BUT we are hopefully moving away from SVN ASAP!
 elif ( svn info &> /dev/null); then
 	version=$(svn info | awk '/^Revision:/ {print $NF}')
 	vcs="svn"
@@ -23,5 +33,15 @@ else
 fi
 
 #echo "version is $version from $vcs"
+if [ "$1" == "vcs" ]; then
+    echo $vcs
+    exit 0
+fi
+
+
+if [ "$1" == "githash" ]; then
+    echo $githash
+    exit 0
+fi
 
 echo $version

--- a/get_version.sh
+++ b/get_version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#don't exit even if a command fails
+set +e
+
+version=0001
+vcs="unknown"
+if ( git log -n 1 &> /dev/null); then
+	#retrieve git information - just get number of commits
+	#note - this will not match svn commits
+	#note - with caves repo - start of history is cutoff? so it is unusually small number
+	#note - should really provide hash of last git commit - this is *much* more handy for unoffical builds!
+	#where a single number is currently rather misleading
+	#though a version numer for approx human reading is nice!
+	version=$(git rev-list HEAD | wc -l)
+	vcs="git"
+elif ( svn info &> /dev/null); then
+	version=$(svn info | awk '/^Revision:/ {print $NF}')
+	vcs="svn"
+else
+    version=0001
+    vcs="error"
+fi
+
+#echo "version is $version from $vcs"
+
+echo $version

--- a/libretroshare/src/auto_version.sh
+++ b/libretroshare/src/auto_version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#don't exit even if a command fails
+set +e
+
+
+version=$(../../get_version.sh)
+
+if [[ ${version} != '' ]]; then
+	echo "Writing version to retroshare/rsautoversion.h : ${version}"
+	echo "#define RS_REVISION_NUMBER $version" > retroshare/rsautoversion.h
+fi
+echo "script auto_version.sh finished normally"
+exit 0

--- a/libretroshare/src/libretroshare.pro
+++ b/libretroshare/src/libretroshare.pro
@@ -161,7 +161,7 @@ linux-* {
 	include_rsiface.files = $$PUBLIC_HEADERS
 	INSTALLS += include_rsiface
 
-	#CONFIG += version_detail_bash_script
+        CONFIG += version_detail_bash_script
 
 
 	# linux/bsd can use either - libupnp is more complete and packaged.
@@ -192,7 +192,7 @@ linux-g++-64 {
 version_detail_bash_script {
     QMAKE_EXTRA_TARGETS += write_version_detail
     PRE_TARGETDEPS = write_version_detail
-    write_version_detail.commands = ./version_detail.sh
+    write_version_detail.commands = ./auto_version.sh
 }
 
 #################### Cross compilation for windows under Linux ####################

--- a/libretroshare/src/retroshare/rsautoversion.h.old
+++ b/libretroshare/src/retroshare/rsautoversion.h.old
@@ -1,0 +1,1 @@
+#define RS_REVISION_NUMBER 0

--- a/libretroshare/src/retroshare/rsversion.h
+++ b/libretroshare/src/retroshare/rsversion.h
@@ -1,5 +1,6 @@
+#include "rsautoversion.h"
 #define RS_MAJOR_VERSION     0
 #define RS_MINOR_VERSION     6
 #define RS_BUILD_NUMBER      0
 #define RS_BUILD_NUMBER_ADD  "x" // <-- do we need this?
-#define RS_REVISION_NUMBER   0001
+//#define RS_REVISION_NUMBER   0001

--- a/retroshare-gui/src/gui/help/version.html
+++ b/retroshare-gui/src/gui/help/version.html
@@ -1,5 +1,0 @@
-Retroshare Gui version : 
-Svn version : 8013
-Fr 13. Mär 16:32:53 CET 2015
-
-

--- a/retroshare-gui/src/gui/help/version.html.old
+++ b/retroshare-gui/src/gui/help/version.html.old
@@ -1,0 +1,5 @@
+Retroshare Gui version : 
+Svn version : 8013
+Fr 13. Mär 16:32:53 CET 2015
+
+

--- a/retroshare-gui/src/retroshare-gui.pro
+++ b/retroshare-gui/src/retroshare-gui.pro
@@ -69,7 +69,7 @@ INCLUDEPATH *= retroshare-gui
 ################################# Linux ##########################################
 # Put lib dir in QMAKE_LFLAGS so it appears before -L/usr/lib
 linux-* {
-	#CONFIG += version_detail_bash_script
+        CONFIG += version_detail_bash_script
 	QMAKE_CXXFLAGS *= -D_FILE_OFFSET_BITS=64
 
 	PRE_TARGETDEPS *= ../../libretroshare/src/lib/libretroshare.a

--- a/retroshare-gui/src/version_detail.sh
+++ b/retroshare-gui/src/version_detail.sh
@@ -6,6 +6,8 @@
 set +e
 
 
+#alternate method from Heini
+#if [[ -c /dev/null ]]; then
 if (ls &> /dev/null); then
 	echo "Retroshare Gui version : " > gui/help/version.html
 	

--- a/retroshare-gui/src/version_detail.sh
+++ b/retroshare-gui/src/version_detail.sh
@@ -11,16 +11,16 @@ set +e
 if (ls &> /dev/null); then
 	echo "Retroshare Gui version : " > gui/help/version.html
 	
-        version=$(../../get_version.sh)
+		version=$(../../get_version.sh)
 
-        vcs=$(../../get_version.sh vcs)
-        githash=$(../../get_version.sh githash)
-        
-        echo "VCS: $vcs" >> gui/help/version.html
-        if [ "$vcs" == "git" ]; then
-            echo "Git Hash : $githash" >> gui/help/version.html
-        fi
-        echo "Revision Number: $version" >> gui/help/version.html
+		vcs=$(../../get_version.sh vcs)
+		githash=$(../../get_version.sh githash)
+		
+		echo "VCS: $vcs" >> gui/help/version.html
+		if [ "$vcs" == "git" ]; then
+			echo "Git Hash : $githash" >> gui/help/version.html
+		fi
+		echo "Revision Number: $version" >> gui/help/version.html
 	date >> gui/help/version.html
 	echo "" >> gui/help/version.html
 	echo "" >> gui/help/version.html

--- a/retroshare-gui/src/version_detail.sh
+++ b/retroshare-gui/src/version_detail.sh
@@ -5,23 +5,20 @@
 #don't exit even if a command fails
 set +e
 
+
 if (ls &> /dev/null); then
 	echo "Retroshare Gui version : " > gui/help/version.html
-	if ( /usr/bin/git log -n 1 &> /dev/null); then
-		#retrieve git information
-		echo "Git version : $(git status | grep branch | cut -c 3-) $(git log -n 1 | grep commit)" >> gui/help/version.html
-	fi
-	if ( /usr/bin/git log -n 1 | grep svn &> /dev/null); then
-		#retrieve git svn information
-		echo "Svn version : $(git log -n 1 | awk '/svn/ {print $2}' | head -1)" >> gui/help/version.html
-	elif ( /usr/bin/git log -n 10 | grep svn &> /dev/null); then
-		#retrieve git svn information
-		echo "Svn closest version : $(git log -n 10 | awk '/svn/ {print $2}' | head -1)" >> gui/help/version.html
-	fi
+	
+        version=$(../../get_version.sh)
 
-	if ( /usr/bin/svn info &> /dev/null); then
-		echo "Svn version : $(svn info | awk '/^Revision:/ {print $NF}')" >> gui/help/version.html
-	fi
+        vcs=$(../../get_version.sh vcs)
+        githash=$(../../get_version.sh githash)
+        
+        echo "VCS: $vcs" >> gui/help/version.html
+        if [ "$vcs" == "git" ]; then
+            echo "Git Hash : $githash" >> gui/help/version.html
+        fi
+        echo "Revision Number: $version" >> gui/help/version.html
 	date >> gui/help/version.html
 	echo "" >> gui/help/version.html
 	echo "" >> gui/help/version.html


### PR DESCRIPTION
This streamlines and enhances the version_detail process to make it automatic
- process called by qmake
- header/html files generated not in vcs
- handles no SVN to some degree!

untested on OSX.
Windows will need some similar powershell scripts?
