### PR TITLE
Betterbugs2

### DIFF
--- a/retroshare-gui/src/gui/AboutDialog.cpp
+++ b/retroshare-gui/src/gui/AboutDialog.cpp
@@ -32,6 +32,7 @@
 #include <microhttpd.h>
 
 #include <QClipboard>
+#include <QSysInfo>
 #include <QHBoxLayout>
 #include <QPainter>
 #include <QBrush>
@@ -756,20 +757,21 @@ void AboutDialog::on_copy_button_clicked()
 
 
 #if QT_VERSION >= QT_VERSION_CHECK (5, 0, 0)
-    //TODO use QT5s nice qsysinfo class!
+	#if QT_VERSION >= QT_VERSION_CHECK (5, 4, 0)
+		verInfo+=QSysInfo::prettyProductName();
+	#endif
 #else
-    #ifdef Q_WS_X11
-    QString OS="Linux";
-    #endif
-    #ifdef Q_WS_WIN
-    QString OS="Windows";
-    #endif
-    #ifdef Q_WS_MACX
-    QString OS="Mac";
-    #endif
-    insertHtml(OS+" ");
+	#ifdef Q_WS_X11
+	verInfo+="Linux";
+	#endif
+	#ifdef Q_WS_WIN
+	verInfo+="Windows";
+	#endif
+	#ifdef Q_WS_MACX
+	verInfo+="Mac";
+	#endif
 #endif
-
+	verInfo+=" ";
     QString qtver = QString("QT ")+QT_VERSION_STR;
     verInfo+=qtver;
     verInfo+="\n\n";

--- a/retroshare-gui/src/gui/AboutDialog.cpp
+++ b/retroshare-gui/src/gui/AboutDialog.cpp
@@ -24,10 +24,14 @@
 #include "HelpDialog.h"
 #include "rshare.h"
 
+#include <retroshare/rsiface.h>
+#include <retroshare/rsplugin.h>
 #include <retroshare/rsdisc.h>
 #include <retroshare/rspeers.h>
 #include "settings/rsharesettings.h"
+#include <microhttpd.h>
 
+#include <QClipboard>
 #include <QHBoxLayout>
 #include <QPainter>
 #include <QBrush>
@@ -720,4 +724,79 @@ NextPieceLabel::NextPieceLabel( QWidget* parent /* = 0*/ ) : QLabel(parent)
     setFrameShape(QFrame::Box);
     setAlignment(Qt::AlignCenter);
     setAutoFillBackground(true);
+}
+
+static QString addLibraries(const std::string &name, const std::list<RsLibraryInfo> &libraries)
+{
+    QString mTextEdit;
+    mTextEdit+=QString::fromUtf8(name.c_str());
+    mTextEdit+="\n";
+
+    std::list<RsLibraryInfo>::const_iterator libraryIt;
+    for (libraryIt = libraries.begin(); libraryIt != libraries.end(); ++libraryIt) {
+
+        mTextEdit+=" - ";
+        mTextEdit+=QString::fromUtf8(libraryIt->mName.c_str());
+        mTextEdit+=": ";
+        mTextEdit+=QString::fromUtf8(libraryIt->mVersion.c_str());
+        mTextEdit+="\n";
+    }
+    mTextEdit+="\n";
+    return mTextEdit;
+}
+
+
+void AboutDialog::on_copy_button_clicked()
+{
+    QString verInfo;
+    QString rsVerString = "RetroShare Version: ";
+    rsVerString+=Rshare::retroshareVersion(true);
+    verInfo+=rsVerString;
+    verInfo+="\n";
+
+
+#if QT_VERSION >= QT_VERSION_CHECK (5, 0, 0)
+    //TODO use QT5s nice qsysinfo class!
+#else
+    #ifdef Q_WS_X11
+    QString OS="Linux";
+    #endif
+    #ifdef Q_WS_WIN
+    QString OS="Windows";
+    #endif
+    #ifdef Q_WS_MACX
+    QString OS="Mac";
+    #endif
+    insertHtml(OS+" ");
+#endif
+
+    QString qtver = QString("QT ")+QT_VERSION_STR;
+    verInfo+=qtver;
+    verInfo+="\n\n";
+
+    /* Add version numbers of libretroshare */
+    std::list<RsLibraryInfo> libraries;
+    RsControl::instance()->getLibraries(libraries);
+    verInfo+=addLibraries("libretroshare", libraries);
+
+    /* Add version numbers of RetroShare */
+    // Add versions here. Find a better place.
+    libraries.clear();
+    libraries.push_back(RsLibraryInfo("Libmicrohttpd", MHD_get_version()));
+    verInfo+=addLibraries("RetroShare", libraries);
+
+    /* Add version numbers of plugins */
+    if (rsPlugins) {
+        for (int i = 0; i < rsPlugins->nbPlugins(); ++i) {
+            RsPlugin *plugin = rsPlugins->plugin(i);
+            if (plugin) {
+                libraries.clear();
+                plugin->getLibraries(libraries);
+                verInfo+=addLibraries(plugin->getPluginName(), libraries);
+            }
+        }
+    }
+
+
+    QApplication::clipboard()->setText(verInfo);
 }

--- a/retroshare-gui/src/gui/AboutDialog.h
+++ b/retroshare-gui/src/gui/AboutDialog.h
@@ -50,6 +50,8 @@ private slots:
     void sl_levelChanged(int);
     void on_help_button_clicked();
 
+    void on_copy_button_clicked();
+
 signals:
     void si_scoreChanged(QString);
     void si_maxScoreChanged(QString);

--- a/retroshare-gui/src/gui/AboutDialog.ui
+++ b/retroshare-gui/src/gui/AboutDialog.ui
@@ -23,7 +23,16 @@
    <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <item>
@@ -53,6 +62,17 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="copy_button">
+       <property name="text">
+        <string>Copy Info</string>
+       </property>
+       <property name="icon">
+        <iconset resource="images.qrc">
+         <normaloff>:/images/copy.png</normaloff>:/images/copy.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -76,7 +96,9 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="images.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>close_button</sender>


### PR DESCRIPTION
## Easy Bug reporting

Clean branch that adds copy info button to about dialog
output like:

RetroShare Version: 0.6.0x Revision 1
Ubuntu 15.04 QT 5.4.1

libretroshare
- bzip2: 1.0.6, 6-Sept-2010
- OpenSSL: OpenSSL 1.0.1f 6 Jan 2014
- SQLCipher: 3.2.0
- Zlib: 1.2.8

RetroShare
- Libmicrohttpd: 0.9.37

screenshot:
![rsverinfo](https://cloud.githubusercontent.com/assets/937160/8889733/6c4e9d0a-32de-11e5-9e56-6a07706d85f7.png)
