### PR TITLE
minor tweak to list friends in order they are shown on graph

### DIFF
--- a/retroshare-gui/src/gui/statistics/GlobalRouterStatistics.cpp
+++ b/retroshare-gui/src/gui/statistics/GlobalRouterStatistics.cpp
@@ -294,6 +294,22 @@ void GlobalRouterStatisticsWidget::updateContent()
     oy += celly ;
     oy += celly ;
 
+	//print friends in the same order their prob is shown
+	QString FO = tr("Friend Order  (");
+	RsPeerDetails peer_ssl_details;
+	for(uint32_t i=0;i<matrix_info.friend_ids.size();++i){
+		rsPeers->getPeerDetails(matrix_info.friend_ids[i], peer_ssl_details);
+		QString fn = QString::fromUtf8(peer_ssl_details.name.c_str());
+		FO+=fn;
+		FO+=" ";
+
+	}
+	FO+=")";
+
+	painter.drawText(ox+0*cellx,oy+fm_times.height(),FO) ;
+	oy += celly ;
+	oy += celly ;
+
     static const int MaxKeySize = 20*fact ;
     painter.setFont(monospace_f) ;
 


### PR DESCRIPTION
![grstatweak](https://cloud.githubusercontent.com/assets/937160/8947044/1a440f1a-358e-11e5-9a7c-b93816dffe5c.png)
Now I can see who those rainbow squares are!
Though, this is by no means a long term solution!
